### PR TITLE
Fix: Dockerfile copy paths

### DIFF
--- a/src/BrewUpApiTemplate/Dockerfile
+++ b/src/BrewUpApiTemplate/Dockerfile
@@ -7,9 +7,9 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
-COPY ["BrewUpApiTemplate/BrewUpApiTemplate.csproj", "BrewUpApiTemplate/"]
+COPY ["BrewUpApiTemplate.csproj", "BrewUpApiTemplate/"]
 RUN dotnet restore "BrewUpApiTemplate/BrewUpApiTemplate.csproj"
-COPY . .
+COPY . BrewUpApiTemplate/
 WORKDIR "/src/BrewUpApiTemplate"
 RUN dotnet build "BrewUpApiTemplate.csproj" -c Release -o /app/build
 


### PR DESCRIPTION
COPY paths are not correct and cause the docker build command to fail